### PR TITLE
Fix: Correct login request format and token handling

### DIFF
--- a/progrex-angular-shell/src/app/core/services/auth.service.ts
+++ b/progrex-angular-shell/src/app/core/services/auth.service.ts
@@ -19,8 +19,8 @@ export interface RegistrationData {
 }
 
 export interface TokenResponse {
-  access: string; // New target based on user feedback
-  token_type: string; // Assuming this part of the structure is still valid
+  access_token: string; // Correct field name
+  token_type: string;
   refresh?: string;
 }
 
@@ -46,8 +46,8 @@ export class AuthService {
     })
       .pipe(
         tap(response => {
-          if (response && response.access) {
-            this.saveToken(response.access);
+          if (response && response.access_token) {
+            this.saveToken(response.access_token);
             // Potentially save refresh token or user details from response
           }
         })

--- a/progrex-angular-shell/src/app/features/auth/login/login.component.ts
+++ b/progrex-angular-shell/src/app/features/auth/login/login.component.ts
@@ -34,13 +34,13 @@ export class LoginComponent implements OnInit {
     if (this.loginForm.valid) {
       this.authService.login(this.loginForm.value).subscribe({
         next: (response: TokenResponse) => {
-          if (response && response.access) {
+          if (response && response.access_token) {
             // Ensure this.authService.saveToken is called by the service's tap operator,
             // so no need to call it directly here.
             this.router.navigate(['/dashboard']);
           } else {
-            // Update error message to reflect expectation of 'access'
-            this.errorMessage = 'Login successful, but no token named "access" received.';
+            // Update error message to reflect expectation of 'access_token'
+            this.errorMessage = 'Login successful, but no token named "access_token" received.';
           }
         },
         error: (err) => {


### PR DESCRIPTION
This commit resolves issues preventing successful user login.

The key changes include:

1.  **Login Request Formatting:** Modified `AuthService` to send login credentials using `HttpParams` and explicitly set the `Content-Type` header to `application/x-www-form-urlencoded`. This ensures the request is correctly formatted for the backend FastAPI endpoint (`/users/token`), which expects `OAuth2PasswordRequestForm` data, resolving previous HTTP 422 Unprocessable Content errors.

2.  **Token Response Handling:** Updated the `TokenResponse` interface in `auth.service.ts` and its usage throughout the frontend (in `auth.service.ts`'s `tap` operator and in `login.component.ts`) to correctly use `access_token` as the field name for the JWT. This aligns with the actual field name being sent by the backend, resolving issues where the token was not being correctly extracted from the response.

These changes ensure that the frontend correctly communicates with the backend's token endpoint and properly processes the received authentication token, enabling successful user login and subsequent authenticated requests.