### PR TITLE
Fix: Add missing routes for dashboard sections and Quick Actions

### DIFF
--- a/progrex-angular-shell/src/app/app.routes.ts
+++ b/progrex-angular-shell/src/app/app.routes.ts
@@ -3,6 +3,10 @@ import { DashboardComponent } from './features/dashboard/dashboard.component';
 import { authGuard } from './core/guards/auth.guard';
 import { adminGuard } from './core/guards/admin.guard'; // Import adminGuard
 import { SettingsComponent } from './features/dashboard/settings/settings.component';
+import { OverviewComponent } from './features/dashboard/overview/overview.component';
+import { GeoZoneCreateComponent } from './features/geozones/components/create/geozone-create.component';
+import { ManageIndicatorsComponent } from './features/indicators/components/manage/manage-indicators.component';
+import { UserProfileComponent } from './features/user/profile/user-profile.component';
 
 export const routes: Routes = [
   {
@@ -18,6 +22,11 @@ export const routes: Routes = [
     path: 'dashboard/settings', // The URL path
     component: SettingsComponent,    // The component to load
     canActivate: [authGuard]       // Protect with authGuard, similar to dashboard
+  },
+  {
+    path: 'dashboard/overview',    // The URL path
+    component: OverviewComponent,  // The component to load
+    canActivate: [authGuard]     // Protect with authGuard, similar to other dashboard routes
   },
   {
     path: '',
@@ -49,6 +58,21 @@ export const routes: Routes = [
     loadChildren: () => import('./features/indicator-values/indicator-values.module').then(m => m.IndicatorValuesModule),
     canActivate: [authGuard]
   },
+  {
+    path: 'geozones/create',
+    component: GeoZoneCreateComponent,
+    canActivate: [authGuard]
+  },
+  {
+    path: 'indicators/manage',
+    component: ManageIndicatorsComponent,
+    canActivate: [authGuard]
+  },
+  {
+    path: 'user/profile',
+    component: UserProfileComponent,
+    canActivate: [authGuard]
+  }
   // Catch-all or 404 route can be added here if needed
   // { path: '**', component: PageNotFoundComponent }
 ];

--- a/progrex-angular-shell/src/app/features/dashboard/overview/overview.component.ts
+++ b/progrex-angular-shell/src/app/features/dashboard/overview/overview.component.ts
@@ -1,0 +1,16 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-overview',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <h2>Dashboard Overview</h2>
+    <p>This is the dashboard overview page.</p>
+  `,
+  styles: [``]
+})
+export class OverviewComponent {
+  constructor() {}
+}

--- a/progrex-angular-shell/src/app/features/geozones/components/create/geozone-create.component.ts
+++ b/progrex-angular-shell/src/app/features/geozones/components/create/geozone-create.component.ts
@@ -1,0 +1,17 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-geozone-create',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <h2>Create New GeoZone</h2>
+    <p>This is where you would add a form to create a new GeoZone.</p>
+    <!-- Placeholder for GeoZone creation form -->
+  `,
+  styles: [``]
+})
+export class GeoZoneCreateComponent {
+  constructor() {}
+}

--- a/progrex-angular-shell/src/app/features/indicators/components/manage/manage-indicators.component.ts
+++ b/progrex-angular-shell/src/app/features/indicators/components/manage/manage-indicators.component.ts
@@ -1,0 +1,17 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-manage-indicators',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <h2>Manage Indicators</h2>
+    <p>This page would be used for managing indicators (e.g., CRUD operations).</p>
+    <!-- Placeholder for indicator management UI -->
+  `,
+  styles: [``]
+})
+export class ManageIndicatorsComponent {
+  constructor() {}
+}

--- a/progrex-angular-shell/src/app/features/user/profile/user-profile.component.ts
+++ b/progrex-angular-shell/src/app/features/user/profile/user-profile.component.ts
@@ -1,0 +1,17 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-user-profile',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <h2>User Profile</h2>
+    <p>This page will display user profile information and allow editing.</p>
+    <!-- Placeholder for user profile details -->
+  `,
+  styles: [``]
+})
+export class UserProfileComponent {
+  constructor() {}
+}


### PR DESCRIPTION
This commit resolves several NG04002 "Cannot match any routes" errors by defining routes and placeholder components for various application sections.

The following routes and components have been added:

1.  **Dashboard Sections:**
    - `dashboard/settings`: Added `SettingsComponent` and route `{ path: 'dashboard/settings', component: SettingsComponent, canActivate: [authGuard] }`. Resolved an issue where `authGuard` initially caused this route to render a blank page.
    - `dashboard/overview`: Added `OverviewComponent` and route `{ path: 'dashboard/overview', component: OverviewComponent, canActivate: [authGuard] }`.

2.  **Quick Actions Links:**
    - `/geozones/create`: Added `GeoZoneCreateComponent` (under `features/geozones/`) and route `{ path: 'geozones/create', component: GeoZoneCreateComponent, canActivate: [authGuard] }`.
    - `/indicators/manage`: Added `ManageIndicatorsComponent` (under `features/indicators/`) and route `{ path: 'indicators/manage', component: ManageIndicatorsComponent, canActivate: [authGuard] }`.
    - `/user/profile`: Added `UserProfileComponent` (under `features/user/`) and route `{ path: 'user/profile', component: UserProfileComponent, canActivate: [authGuard] }`.

All new routes are protected by `authGuard`. These changes ensure that navigation to these sections and clicks on the Quick Actions links now correctly load their respective placeholder pages without routing errors.

Further work will involve implementing the actual functionality within these new components.