### PR TITLE
Fix: Make Quick Actions links clickable in DashboardComponent

### DIFF
--- a/progrex-angular-shell/src/app/features/dashboard/dashboard.component.ts
+++ b/progrex-angular-shell/src/app/features/dashboard/dashboard.component.ts
@@ -1,11 +1,12 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AuthService } from '../../core/services/auth.service'; // Corrected path
+import { RouterLink } from '@angular/router';
 
 @Component({
   selector: 'app-dashboard',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, RouterLink], // Added RouterLink here
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.css'] // Corrected to styleUrls
 })


### PR DESCRIPTION
The "Quick Actions" links within the DashboardComponent were not functional because DashboardComponent, as a standalone component, was missing `RouterLink` in its `imports` array.

This commit adds `RouterLink` from `@angular/router` to the `imports` array of `DashboardComponent` in `progrex-angular-shell/src/app/features/dashboard/dashboard.component.ts`.

This change enables the `routerLink` directives in the DashboardComponent's template, allowing the Quick Actions links ("Create New GeoZone", "Manage Indicators", "View Your Profile") to navigate to their respective routes correctly.