### PR TITLE
Here's the plan:

### DIFF
--- a/progrex-angular-shell/src/app/features/dashboard/overview/overview.component.ts
+++ b/progrex-angular-shell/src/app/features/dashboard/overview/overview.component.ts
@@ -1,16 +1,48 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router'; // Import RouterLink
+import { CountryService } from '../../../core/services/country.service';
+// Country model might not be strictly needed if we only use .length
 
 @Component({
   selector: 'app-overview',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, RouterLink], // Add RouterLink
   template: `
     <h2>Dashboard Overview</h2>
-    <p>This is the dashboard overview page.</p>
+    <div *ngIf="isLoading">Loading country data...</div>
+    <div *ngIf="errorMessage">
+      <p style="color: red;">{{ errorMessage }}</p>
+    </div>
+    <div *ngIf="!isLoading && !errorMessage">
+      <h3>Country Summary</h3>
+      <p>Total Countries in System: {{ countryCount }}</p>
+      <p><a routerLink="/countries">View All Countries</a></p>
+    </div>
+    <hr>
+    <p>More overview content will go here.</p>
   `,
   styles: [``]
 })
-export class OverviewComponent {
-  constructor() {}
+export class OverviewComponent implements OnInit {
+  countryCount: number = 0;
+  isLoading: boolean = true;
+  errorMessage: string | null = null;
+
+  constructor(private countryService: CountryService) {}
+
+  ngOnInit(): void {
+    this.isLoading = true;
+    this.countryService.getCountries().subscribe({ // Get all countries
+      next: (countries) => {
+        this.countryCount = countries.length;
+        this.isLoading = false;
+      },
+      error: (err) => {
+        console.error('Error fetching countries for overview:', err);
+        this.errorMessage = 'Could not load country data.';
+        this.isLoading = false;
+      }
+    });
+  }
 }


### PR DESCRIPTION
Feat: Implement basic Dashboard Overview with country count

Adds a basic implementation to the Dashboard Overview page:
- Fetches the list of all countries from `CountryService`.
- Displays the total count of countries.
- Provides a link to the main countries page.
- Includes loading and error states for the data fetching operation.

This provides an initial piece of dynamic content on the overview page.