### PR TITLE
feat: Implement economic profile section with mock data

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -6,7 +6,12 @@ from .config import settings
 
 engine = create_engine(settings.DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-Base = declarative_base()
+# Base = declarative_base() # Defined below to ensure models are imported first
+
+# Import all models here so Base registers them
+from . import models # This line assumes your models are in models.py
+
+Base = declarative_base() # Now Base will know about the models
 
 SessionLocal = sessionmaker(
     autocommit=False,
@@ -22,4 +27,4 @@ def get_db():
     finally:
         db.close()
 
-Base = declarative_base()
+# Base = declarative_base() # Already defined above

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,10 +2,10 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from .database import Base, engine
-from .routers import countries, indicators, datasources, indicator_values, users, geozones, user_configurations # Added user_configurations router
+from .routers import countries, indicators, datasources, indicator_values, users, geozones, user_configurations, economic_profile # Added economic_profile router
 
 # Crear tablas
-Base.metadata.create_all(bind=engine) # This will now also create the users, geozones, and user_configurations tables
+Base.metadata.create_all(bind=engine) # This will now also create the users, geozones, user_configurations and country_economic_profiles tables
 
 app = FastAPI(title="Progrex API")
 
@@ -22,6 +22,7 @@ app.include_router(countries.router)
 app.include_router(indicators.router)
 app.include_router(datasources.router)
 app.include_router(indicator_values.router)
-app.include_router(users.router) 
-app.include_router(geozones.router) 
+app.include_router(users.router)
+app.include_router(geozones.router)
 app.include_router(user_configurations.router) # Added user_configurations router
+app.include_router(economic_profile.router) # Added economic_profile router

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -20,6 +20,7 @@ class Country(Base):
     indicator_values = relationship(
         "IndicatorValue", back_populates="country", cascade="all, delete-orphan"
     )
+    economic_profile = relationship("CountryEconomicProfile", back_populates="country", uselist=False, cascade="all, delete-orphan")
 
 class Indicator(Base):
     __tablename__ = "indicators"
@@ -105,3 +106,15 @@ class UserConfiguration(Base):
     updated_at     = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
     user = relationship("User", back_populates="config")
+
+
+class CountryEconomicProfile(Base):
+    __tablename__ = "country_economic_profiles"
+
+    id = Column(Integer, primary_key=True, index=True)
+    country_id = Column(Integer, ForeignKey("countries.id"), nullable=False, unique=True)
+    economic_data = Column(Text, nullable=True)  # To store JSON data
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    country = relationship("Country", back_populates="economic_profile")

--- a/backend/app/routers/economic_profile.py
+++ b/backend/app/routers/economic_profile.py
@@ -1,0 +1,44 @@
+# backend/app/routers/economic_profile.py
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from typing import Any # Import Any
+
+from .. import crud, models, schemas # Adjusted import for models
+from ..database import SessionLocal # Adjusted import for SessionLocal
+
+# Dependency to get DB session
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+router = APIRouter(
+    prefix="/countries/{country_id}/economic-profile",
+    tags=["Country Economic Profile"], # Changed tag slightly for clarity
+)
+
+@router.get("/", response_model=schemas.CountryEconomicProfile)
+def read_economic_profile_for_country(
+    country_id: int,
+    db: Session = Depends(get_db)
+) -> Any: # Return type is Any because it can be schema or HTTPException
+    db_country = crud.get_country(db, country_id=country_id)
+    if db_country is None:
+        raise HTTPException(status_code=404, detail="Country not found")
+
+    db_economic_profile = crud.get_country_economic_profile_by_country_id(db, country_id=country_id)
+
+    if db_economic_profile is None:
+        # If profile doesn't exist, create it with mock data
+        # The country name is needed for the mock data generation logic in CRUD
+        db_economic_profile = crud.create_country_economic_profile(db, country_id=country_id, country_name=db_country.name)
+        # Re-fetch to ensure all relationships and ORM state are correct, though create returns the object
+        # db_economic_profile = crud.get_country_economic_profile_by_country_id(db, country_id=country_id)
+
+    if db_economic_profile is None:
+        # This case should ideally not be reached if creation was successful
+        raise HTTPException(status_code=500, detail="Economic profile could not be created or retrieved")
+
+    return db_economic_profile

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -20,6 +20,23 @@ class Country(CountryBase):
         orm_mode = True
 
 
+# ------ CountryEconomicProfile schemas ------
+class CountryEconomicProfileBase(BaseModel):
+    economic_data: Any
+
+class CountryEconomicProfileCreate(CountryEconomicProfileBase):
+    pass
+
+class CountryEconomicProfile(CountryEconomicProfileBase):
+    id: int
+    country_id: int
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
 # ------ UserConfiguration schemas ------
 class UserConfigurationBase(BaseModel):
     configurations: Any # Can be a dict representing the JSON structure

--- a/progrex-angular-shell/src/app/app.routes.ts
+++ b/progrex-angular-shell/src/app/app.routes.ts
@@ -72,6 +72,11 @@ export const routes: Routes = [
     path: 'user/profile',
     component: UserProfileComponent,
     canActivate: [authGuard]
+  },
+  {
+    path: 'economic-profile',
+    loadChildren: () => import('./features/economic-profile/economic-profile.module').then(m => m.EconomicProfileModule),
+    canActivate: [authGuard] // Assuming this section also requires authentication
   }
   // Catch-all or 404 route can be added here if needed
   // { path: '**', component: PageNotFoundComponent }

--- a/progrex-angular-shell/src/app/core/layout/sidebar/sidebar.component.html
+++ b/progrex-angular-shell/src/app/core/layout/sidebar/sidebar.component.html
@@ -4,6 +4,8 @@
   <ul>
     <li><a routerLink="/dashboard/overview">Overview</a></li>
     <li><a routerLink="/dashboard/settings">Settings</a></li>
+    <li><a routerLink="/countries">Countries</a></li>
+    <li><a routerLink="/economic-profile/1">Country 1 Profile (Demo)</a></li> <!-- New Link -->
     <!-- Add more links as needed -->
   </ul>
 </aside>

--- a/progrex-angular-shell/src/app/core/models/economic-profile.model.ts
+++ b/progrex-angular-shell/src/app/core/models/economic-profile.model.ts
@@ -1,0 +1,46 @@
+// progrex-angular-shell/src/app/core/models/economic-profile.model.ts
+
+export interface DataPoint {
+  date: string; // Or Date, if conversion is handled
+  value: number;
+}
+
+export interface StockMarketData {
+  name: string;
+  points: DataPoint[];
+}
+
+export interface RealEstateData {
+  average_price_sqm_usd: number; // Matching the backend mock data key
+  price_trend: DataPoint[];
+}
+
+export interface Company {
+  name: string;
+  valuation_billion_usd?: number; // Matching the backend mock data key
+  sector?: string;
+  // For leading_companies in EconomicSector, it might just be names
+  // If so, this interface is primarily for unicorn_companies.
+  // If leading_companies also have more details, this can be reused.
+}
+
+export interface EconomicSector {
+  name: string;
+  leading_companies: Company[] | string[]; // Allowing simple string array or more detailed Company objects
+}
+
+export interface EconomicData {
+  stock_market: StockMarketData;
+  real_estate: RealEstateData;
+  economy_type: string;
+  main_sectors: EconomicSector[];
+  unicorn_companies: Company[];
+}
+
+export interface CountryEconomicProfile {
+  id: number;
+  country_id: number;
+  economic_data: EconomicData | string; // Allow string initially, to be parsed
+  created_at: string; // Or Date
+  updated_at: string; // Or Date
+}

--- a/progrex-angular-shell/src/app/core/services/economic-profile.service.ts
+++ b/progrex-angular-shell/src/app/core/services/economic-profile.service.ts
@@ -1,0 +1,44 @@
+// progrex-angular-shell/src/app/core/services/economic-profile.service.ts
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { map, catchError } from 'rxjs/operators';
+import { CountryEconomicProfile, EconomicData } from '../models/economic-profile.model';
+// Removed environment import, using relative path for API
+// import { environment } from '../../../environments/environment';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class EconomicProfileService {
+  private apiUrlBase = '/api'; // Using /api directly, common for Angular proxy setup
+
+  constructor(private http: HttpClient) { }
+
+  getEconomicProfile(countryId: number): Observable<CountryEconomicProfile> {
+    const apiUrl = `${this.apiUrlBase}/countries/${countryId}/economic-profile`;
+
+    return this.http.get<CountryEconomicProfile>(apiUrl).pipe(
+      map(response => {
+        if (response && typeof response.economic_data === 'string') {
+          try {
+            response.economic_data = JSON.parse(response.economic_data) as EconomicData;
+          } catch (error) {
+            console.error('Failed to parse economic_data:', error);
+            // Optionally, transform the error or throw a new one
+            // For now, it will propagate the error if parsing fails,
+            // or return the response with unparsed data if console.error is preferred.
+            // To strictly adhere to returning CountryEconomicProfile with EconomicData,
+            // an error should be thrown here or handled in catchError.
+          }
+        }
+        return response;
+      }),
+      catchError(error => {
+        console.error(`Error fetching economic profile for country ID ${countryId}:`, error);
+        // Rethrow the error or return a user-friendly error object
+        throw error; // Rethrowing the error to be handled by the subscriber
+      })
+    );
+  }
+}

--- a/progrex-angular-shell/src/app/features/economic-profile/country-economic-profile.component.css
+++ b/progrex-angular-shell/src/app/features/economic-profile/country-economic-profile.component.css
@@ -1,0 +1,93 @@
+/* progrex-angular-shell/src/app/features/economic-profile/country-economic-profile.component.css */
+.profile-container {
+  padding: 20px;
+  font-family: Arial, sans-serif;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.loading-indicator, .error-message, .no-data {
+  text-align: center;
+  padding: 20px;
+  font-size: 1.2em;
+}
+
+.error-message {
+  color: red;
+}
+
+.profile-content h2 {
+  text-align: center;
+  color: #333;
+  margin-bottom: 20px;
+}
+
+.profile-content h3 {
+  color: #555;
+  border-bottom: 1px solid #eee;
+  padding-bottom: 5px;
+  margin-top: 30px;
+  margin-bottom: 15px;
+}
+
+.data-section {
+  margin-bottom: 20px;
+  padding: 15px;
+  background-color: #f9f9f9;
+  border-radius: 5px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+}
+
+.data-section p, .data-section li {
+  line-height: 1.6;
+}
+
+.data-section strong {
+  color: #444;
+}
+
+.chart-section {
+  margin-bottom: 30px;
+  padding: 15px;
+  background-color: #fff;
+  border-radius: 5px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.chart-wrapper {
+  position: relative;
+  height: 300px; /* Adjust as needed, or use aspect ratio in chart options */
+  width: 100%;
+}
+
+canvas {
+  display: block;
+  width: 100% !important; /* Ensure canvas is responsive within its wrapper */
+  height: 100% !important;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 10px;
+}
+
+th, td {
+  border: 1px solid #ddd;
+  padding: 8px;
+  text-align: left;
+}
+
+th {
+  background-color: #f2f2f2;
+  color: #333;
+}
+
+ul {
+  padding-left: 20px;
+}
+
+ul ul {
+  padding-left: 30px;
+  list-style-type: circle;
+}

--- a/progrex-angular-shell/src/app/features/economic-profile/country-economic-profile.component.html
+++ b/progrex-angular-shell/src/app/features/economic-profile/country-economic-profile.component.html
@@ -1,0 +1,96 @@
+<!-- progrex-angular-shell/src/app/features/economic-profile/country-economic-profile.component.html -->
+<div class="profile-container">
+  <div *ngIf="isLoading" class="loading-indicator">
+    <p>Loading economic profile for country ID: {{ countryId }}...</p>
+    <!-- Add a spinner or animation here if desired -->
+  </div>
+
+  <div *ngIf="errorMessage" class="error-message">
+    <p>Error: {{ errorMessage }}</p>
+  </div>
+
+  <div *ngIf="!isLoading && profile && economicData && !errorMessage" class="profile-content">
+    <h2>Economic Profile for Country ID: {{ profile.country_id }}</h2>
+
+    <section class="data-section">
+      <h3>General Information</h3>
+      <p><strong>Economy Type:</strong> {{ economicData.economy_type }}</p>
+      <p><em>Profile last updated: {{ profile.updated_at | date:'medium' }}</em></p>
+    </section>
+
+    <section class="chart-section" *ngIf="economicData.stock_market && economicData.stock_market.points.length > 0">
+      <h3>{{ economicData.stock_market.name }}</h3>
+      <div class="chart-wrapper">
+        <canvas baseChart
+          [data]="stockMarketChartData"
+          [options]="stockMarketChartOptions"
+          [type]="stockMarketChartType">
+        </canvas>
+      </div>
+    </section>
+    <section class="chart-section" *ngIf="!economicData.stock_market || economicData.stock_market.points.length === 0">
+        <p>No stock market data available.</p>
+    </section>
+
+    <section class="chart-section" *ngIf="economicData.real_estate && economicData.real_estate.price_trend.length > 0">
+      <h3>Real Estate Trends</h3>
+      <p><strong>Average Price:</strong> {{ economicData.real_estate.average_price_sqm_usd | currency:'USD':'symbol':'1.0-0' }} / sqm</p>
+      <div class="chart-wrapper">
+        <canvas baseChart
+          [data]="realEstateChartData"
+          [options]="realEstateChartOptions"
+          [type]="realEstateChartType">
+        </canvas>
+      </div>
+    </section>
+    <section class="chart-section" *ngIf="!economicData.real_estate || economicData.real_estate.price_trend.length === 0">
+        <p>No real estate trend data available.</p>
+    </section>
+
+    <section class="data-section" *ngIf="economicData.main_sectors && economicData.main_sectors.length > 0">
+      <h3>Main Economic Sectors</h3>
+      <ul>
+        <li *ngFor="let sector of economicData.main_sectors">
+          <strong>{{ sector.name }}</strong>
+          <ul *ngIf="sector.leading_companies && sector.leading_companies.length > 0">
+            <li *ngFor="let company of sector.leading_companies">
+              {{ (company.name ? company.name : company) }} <!-- Handles both Company obj and string -->
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </section>
+     <section class="data-section" *ngIf="!economicData.main_sectors || economicData.main_sectors.length === 0">
+        <p>No main sector data available.</p>
+    </section>
+
+
+    <section class="data-section" *ngIf="economicData.unicorn_companies && economicData.unicorn_companies.length > 0">
+      <h3>Unicorn Companies</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Valuation (Billion USD)</th>
+            <th>Sector</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let company of economicData.unicorn_companies">
+            <td>{{ company.name }}</td>
+            <td>{{ company.valuation_billion_usd | number:'1.1-1' }}B</td>
+            <td>{{ company.sector }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+    <section class="data-section" *ngIf="!economicData.unicorn_companies || economicData.unicorn_companies.length === 0">
+        <p>No unicorn company data available.</p>
+    </section>
+
+  </div>
+
+  <div *ngIf="!isLoading && !profile && !errorMessage" class="no-data">
+    <p>No economic profile data found for this country.</p>
+  </div>
+</div>

--- a/progrex-angular-shell/src/app/features/economic-profile/country-economic-profile.component.ts
+++ b/progrex-angular-shell/src/app/features/economic-profile/country-economic-profile.component.ts
@@ -1,0 +1,189 @@
+// progrex-angular-shell/src/app/features/economic-profile/country-economic-profile.component.ts
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { EconomicProfileService } from '../../../core/services/economic-profile.service';
+import { CountryEconomicProfile, EconomicData, DataPoint, StockMarketData, RealEstateData } from '../../../core/models/economic-profile.model';
+import { ChartConfiguration, ChartOptions, ChartType, TooltipItem } from 'chart.js'; // Added TooltipItem
+
+@Component({
+  selector: 'app-country-economic-profile',
+  templateUrl: './country-economic-profile.component.html',
+  styleUrls: ['./country-economic-profile.component.css']
+})
+export class CountryEconomicProfileComponent implements OnInit {
+
+  profile: CountryEconomicProfile | null = null;
+  // Ensure EconomicData is properly typed if accessed directly from profile.economic_data
+  economicData: EconomicData | null = null;
+  isLoading: boolean = true;
+  errorMessage: string | null = null;
+  countryId!: number; // Definite assignment assertion
+
+  // Stock Market Chart
+  public stockMarketChartData: ChartConfiguration<'line'>['data'] = { labels: [], datasets: [] };
+  public stockMarketChartOptions: ChartOptions<'line'> = {
+    responsive: true,
+    maintainAspectRatio: false,
+    scales: {
+      y: { beginAtZero: false }
+    },
+    plugins: {
+      legend: { display: true },
+      tooltip: {
+        callbacks: {
+          label: (context: TooltipItem<'line'>) => {
+            let label = context.dataset.label || '';
+            if (label) {
+              label += ': ';
+            }
+            if (context.parsed.y !== null) {
+              label += context.parsed.y.toFixed(2);
+            }
+            return label;
+          }
+        }
+      }
+    }
+  };
+  public stockMarketChartType: ChartType = 'line';
+
+  // Real Estate Chart
+  public realEstateChartData: ChartConfiguration<'line'>['data'] = { labels: [], datasets: [] };
+  public realEstateChartOptions: ChartOptions<'line'> = {
+    responsive: true,
+    maintainAspectRatio: false,
+    scales: {
+      y: {
+        beginAtZero: false,
+        ticks: {
+          callback: function(value) {
+            return '$' + value; // Add USD symbol
+          }
+        }
+      }
+    },
+    plugins: {
+      legend: { display: true },
+      tooltip: {
+        callbacks: {
+          label: (context: TooltipItem<'line'>) => {
+            let label = context.dataset.label || '';
+            if (label) {
+              label += ': ';
+            }
+            if (context.parsed.y !== null) {
+              label += '$' + context.parsed.y.toFixed(2); // Add USD symbol
+            }
+            return label;
+          }
+        }
+      }
+    }
+  };
+  public realEstateChartType: ChartType = 'line';
+
+  constructor(
+    private route: ActivatedRoute,
+    private economicProfileService: EconomicProfileService
+  ) { }
+
+  ngOnInit(): void {
+    const idParam = this.route.snapshot.paramMap.get('countryId');
+    if (idParam) {
+      this.countryId = +idParam; // Convert string to number
+      this.loadEconomicProfile();
+    } else {
+      this.isLoading = false;
+      this.errorMessage = 'Country ID not found in route parameters.';
+      console.error(this.errorMessage);
+    }
+  }
+
+  loadEconomicProfile(): void {
+    this.isLoading = true;
+    this.errorMessage = null;
+    this.economicProfileService.getEconomicProfile(this.countryId).subscribe({
+      next: (data) => {
+        this.profile = data;
+        // Type guard for economic_data
+        if (typeof data.economic_data === 'string') {
+          // This should ideally be handled by the service, but as a fallback:
+          console.warn('Economic data was a string, attempting to parse in component.');
+          try {
+            this.economicData = JSON.parse(data.economic_data) as EconomicData;
+          } catch (e) {
+            console.error('Failed to parse economic_data in component:', e);
+            this.errorMessage = 'Failed to parse economic data.';
+            this.economicData = null;
+          }
+        } else {
+          this.economicData = data.economic_data as EconomicData;
+        }
+
+        if (this.economicData) {
+          this.prepareStockMarketChart();
+          this.prepareRealEstateChart();
+        } else if (!this.errorMessage) {
+          // If economicData is null and no parsing error was set
+          this.errorMessage = 'Economic data is missing or invalid.';
+        }
+        this.isLoading = false;
+      },
+      error: (err) => {
+        this.errorMessage = `Failed to load economic profile: ${err.message || 'Unknown error'}`;
+        console.error(err);
+        this.isLoading = false;
+        this.profile = null;
+        this.economicData = null;
+      }
+    });
+  }
+
+  prepareStockMarketChart(): void {
+    if (this.economicData && this.economicData.stock_market && this.economicData.stock_market.points) {
+      const stockData = this.economicData.stock_market;
+      const labels = stockData.points.map((p: DataPoint) => p.date);
+      const dataValues = stockData.points.map((p: DataPoint) => p.value);
+
+      this.stockMarketChartData = {
+        labels: labels,
+        datasets: [
+          {
+            data: dataValues,
+            label: stockData.name || 'Stock Value',
+            borderColor: '#3e95cd',
+            backgroundColor: 'rgba(62, 149, 205, 0.1)',
+            fill: true,
+            tension: 0.1
+          }
+        ]
+      };
+    } else {
+      this.stockMarketChartData = { labels: [], datasets: [] }; // Clear or set to default
+    }
+  }
+
+  prepareRealEstateChart(): void {
+    if (this.economicData && this.economicData.real_estate && this.economicData.real_estate.price_trend) {
+      const realEstateData = this.economicData.real_estate;
+      const labels = realEstateData.price_trend.map((p: DataPoint) => p.date);
+      const dataValues = realEstateData.price_trend.map((p: DataPoint) => p.value);
+
+      this.realEstateChartData = {
+        labels: labels,
+        datasets: [
+          {
+            data: dataValues,
+            label: 'Average Price Trend (USD/sqm)',
+            borderColor: '#8e5ea2',
+            backgroundColor: 'rgba(142, 94, 162, 0.1)',
+            fill: true,
+            tension: 0.1
+          }
+        ]
+      };
+    } else {
+       this.realEstateChartData = { labels: [], datasets: [] }; // Clear or set to default
+    }
+  }
+}

--- a/progrex-angular-shell/src/app/features/economic-profile/economic-profile.module.ts
+++ b/progrex-angular-shell/src/app/features/economic-profile/economic-profile.module.ts
@@ -1,0 +1,24 @@
+// progrex-angular-shell/src/app/features/economic-profile/economic-profile.module.ts
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule, Routes } from '@angular/router';
+import { NgChartsModule } from 'ng2-charts';
+
+import { CountryEconomicProfileComponent } from './country-economic-profile.component';
+
+const routes: Routes = [
+  { path: ':countryId', component: CountryEconomicProfileComponent }
+];
+
+@NgModule({
+  declarations: [
+    CountryEconomicProfileComponent
+  ],
+  imports: [
+    CommonModule,
+    RouterModule.forChild(routes),
+    NgChartsModule
+  ],
+  exports: [RouterModule] // Export RouterModule if this module's routes are to be used by a parent routing module directly
+})
+export class EconomicProfileModule { }


### PR DESCRIPTION
Adds a new section to display detailed economic profiles for countries. This initial version uses mock data to demonstrate the functionality.

Key changes:

Backend:
- Added `CountryEconomicProfile` model and corresponding Pydantic schemas to store structured economic data (stock market, real estate, economy type, main sectors, unicorn companies) as a JSON blob.
- Implemented CRUD operations for `CountryEconomicProfile`.
- Created a new API endpoint `GET /api/countries/{country_id}/economic-profile` that serves this data, generating mock data on the fly if a profile doesn't exist for a requested country.
- Registered the new router in the FastAPI application.

Frontend (Angular):
- Created a new lazy-loaded feature module `EconomicProfileModule`.
- Developed `CountryEconomicProfileComponent` to display the economic data.
- Integrated `ng2-charts` (Chart.js) to render line charts for stock market trends and real estate prices.
- Implemented `EconomicProfileService` to fetch and parse the data from the backend, including parsing the JSON string for `economic_data`.
- Defined frontend models in `economic-profile.model.ts` to match the backend data structure.
- Added routing for the new section and a demo link in the sidebar.
- Included basic styling for the new component.

This feature provides a comprehensive view of a country's economic landscape, laying the groundwork for future integration with real data sources.