### PR TITLE
Refactor database and models to fix circular import

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -4,14 +4,9 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 from .config import settings
 
+Base = declarative_base()
 engine = create_engine(settings.DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-# Base = declarative_base() # Defined below to ensure models are imported first
-
-# Import all models here so Base registers them
-from . import models # This line assumes your models are in models.py
-
-Base = declarative_base() # Now Base will know about the models
 
 SessionLocal = sessionmaker(
     autocommit=False,
@@ -26,5 +21,3 @@ def get_db():
         yield db
     finally:
         db.close()
-
-# Base = declarative_base() # Already defined above


### PR DESCRIPTION
I moved `Base = declarative_base()` to the top of `database.py` and removed the direct import of `models.py` from `database.py` to resolve a circular dependency.

This ensures that `Base` is available when `models.py` imports it, preventing an `ImportError` during application startup. Table creation in `main.py` remains unaffected as models are loaded via router imports before `Base.metadata.create_all()` is called.