### PR TITLE
Fix(template): Resolve template errors in CountryEconomicProfileCompo…

### DIFF
--- a/progrex-angular-shell/src/app/features/economic-profile/country-economic-profile.component.html
+++ b/progrex-angular-shell/src/app/features/economic-profile/country-economic-profile.component.html
@@ -10,16 +10,16 @@
   </div>
 
   <div *ngIf="!isLoading && profile && economicData && !errorMessage" class="profile-content">
-    <h2>Economic Profile for Country ID: {{ profile?.country_id }}</h2>
+    <h2>Economic Profile for Country ID: {{ profile.country_id }}</h2>
     
     <section class="data-section">
       <h3>General Information</h3>
-      <p><strong>Economy Type:</strong> {{ economicData?.economy_type }}</p>
-      <p><em>Profile last updated: {{ profile?.updated_at | date:'medium' }}</em></p>
+      <p><strong>Economy Type:</strong> {{ economicData.economy_type }}</p>
+      <p><em>Profile last updated: {{ profile.updated_at | date:'medium' }}</em></p>
     </section>
 
-    <section class="chart-section" *ngIf="economicData?.stock_market?.points && economicData?.stock_market?.points.length > 0">
-      <h3>{{ economicData?.stock_market?.name }}</h3>
+    <section class="chart-section" *ngIf="economicData.stock_market && economicData.stock_market.points && economicData.stock_market.points.length > 0">
+      <h3>{{ economicData.stock_market.name }}</h3>
       <div class="chart-wrapper">
         <canvas baseChart
           [data]="stockMarketChartData"
@@ -28,13 +28,13 @@
         </canvas>
       </div>
     </section>
-    <section class="chart-section" *ngIf="!economicData?.stock_market?.points || economicData?.stock_market?.points.length === 0">
+    <section class="chart-section" *ngIf="!economicData.stock_market || !economicData.stock_market.points || economicData.stock_market.points.length === 0">
         <p>No stock market data available.</p>
     </section>
 
-    <section class="chart-section" *ngIf="economicData?.real_estate?.price_trend && economicData?.real_estate?.price_trend.length > 0">
+    <section class="chart-section" *ngIf="economicData.real_estate && economicData.real_estate.price_trend && economicData.real_estate.price_trend.length > 0">
       <h3>Real Estate Trends</h3>
-      <p><strong>Average Price:</strong> {{ economicData?.real_estate?.average_price_sqm_usd | currency:'USD':'symbol':'1.0-0' }} / sqm</p>
+      <p><strong>Average Price:</strong> {{ economicData.real_estate.average_price_sqm_usd | currency:'USD':'symbol':'1.0-0' }} / sqm</p>
       <div class="chart-wrapper">
         <canvas baseChart
           [data]="realEstateChartData"
@@ -43,29 +43,30 @@
         </canvas>
       </div>
     </section>
-    <section class="chart-section" *ngIf="!economicData?.real_estate?.price_trend || economicData?.real_estate?.price_trend.length === 0">
+    <section class="chart-section" *ngIf="!economicData.real_estate || !economicData.real_estate.price_trend || economicData.real_estate.price_trend.length === 0">
         <p>No real estate trend data available.</p>
     </section>
 
-    <section class="data-section" *ngIf="economicData?.main_sectors && economicData?.main_sectors.length > 0">
+    <section class="data-section" *ngIf="economicData.main_sectors && economicData.main_sectors.length > 0">
       <h3>Main Economic Sectors</h3>
       <ul>
-        <li *ngFor="let sector of economicData?.main_sectors">
+        <li *ngFor="let sector of economicData.main_sectors">
           <strong>{{ sector.name }}</strong>
           <ul *ngIf="sector.leading_companies && sector.leading_companies.length > 0">
             <li *ngFor="let company of sector.leading_companies">
-              {{ (company.name ? company.name : company) }} <!-- Handles both Company obj and string -->
+              <span *ngIf="company.name">{{ company.name }}</span>
+              <span *ngIf="!company.name">{{ company }}</span> <!-- Handles both Company obj and string -->
             </li>
           </ul>
         </li>
       </ul>
     </section>
-     <section class="data-section" *ngIf="!economicData?.main_sectors || economicData?.main_sectors.length === 0">
+     <section class="data-section" *ngIf="!economicData.main_sectors || economicData.main_sectors.length === 0">
         <p>No main sector data available.</p>
     </section>
 
 
-    <section class="data-section" *ngIf="economicData?.unicorn_companies && economicData?.unicorn_companies.length > 0">
+    <section class="data-section" *ngIf="economicData.unicorn_companies && economicData.unicorn_companies.length > 0">
       <h3>Unicorn Companies</h3>
       <table>
         <thead>
@@ -76,7 +77,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr *ngFor="let company of economicData?.unicorn_companies">
+          <tr *ngFor="let company of economicData.unicorn_companies">
             <td>{{ company.name }}</td>
             <td>{{ company.valuation_billion_usd | number:'1.1-1' }}B</td>
             <td>{{ company.sector }}</td>
@@ -84,7 +85,7 @@
         </tbody>
       </table>
     </section>
-    <section class="data-section" *ngIf="!economicData?.unicorn_companies || economicData?.unicorn_companies.length === 0">
+    <section class="data-section" *ngIf="!economicData.unicorn_companies || economicData.unicorn_companies.length === 0">
         <p>No unicorn company data available.</p>
     </section>
 


### PR DESCRIPTION
…nent

Corrects multiple errors in the `country-economic-profile.component.html` template:
- Addresses NG8107 warnings by removing unnecessary optional chaining (`?.`) for properties that are already guarded by `*ngIf`.
- Fixes NG2 errors (Object is possibly 'undefined') by ensuring `*ngIf` conditions correctly check for the existence of objects and their nested properties before access. This includes `profile`, `economicData`, and its nested fields like `stock_market`, `real_estate`, `main_sectors`, and `unicorn_companies`.
- Resolves NG2 type error for `*ngFor` iterating over `sector.leading_companies` (which can be `string[] | Company[]`) by refining the display logic to explicitly handle both cases using `*ngIf` on `company.name`. This also fixes the related NG9 error (Property 'name' does not exist on type 'string').
- The NG2 errors related to chart types (`[type]="stockMarketChartType"` and `[type]="realEstateChartType"`) are presumed to be secondary effects of the other template errors and should be resolved by these fixes, as your component's TypeScript definitions for these chart types are correct.

The changes ensure safer property access and more robust type handling in the template, leading to a more stable component rendering.