### PR TITLE
Fix(economic-profile): Resolve type errors in template

### DIFF
--- a/progrex-angular-shell/src/app/features/economic-profile/country-economic-profile.component.html
+++ b/progrex-angular-shell/src/app/features/economic-profile/country-economic-profile.component.html
@@ -53,7 +53,7 @@
         <li *ngFor="let sector of economicData.main_sectors">
           <strong>{{ sector.name }}</strong>
           <ul *ngIf="sector.leading_companies && sector.leading_companies.length > 0">
-            <li *ngFor="let company of sector.leading_companies">
+            <li *ngFor="let company of $any(sector.leading_companies)">
               <span *ngIf="typeof company === 'object' && company.name">{{ company.name }}</span>
               <span *ngIf="typeof company === 'string'">{{ company }}</span>
             </li>


### PR DESCRIPTION
The `sector.leading_companies` property can be either a string array or a Company array. The `*ngFor` directive was trying to iterate over it as if it was always a Company array, leading to type errors.

This commit fixes the issue by using `$any()` to bypass strict type checking for this specific loop. The existing `*ngIf` conditions within the loop already handle the different types of the `company` variable.