### PR TITLE
Fix: Address template errors in Uruguay Dashboard

### DIFF
--- a/progrex-angular-shell/src/app/features/uruguay-dashboard/pages/uruguay-dashboard-page/uruguay-dashboard-page.component.html
+++ b/progrex-angular-shell/src/app/features/uruguay-dashboard/pages/uruguay-dashboard-page/uruguay-dashboard-page.component.html
@@ -78,14 +78,14 @@
 
       <div class="profile-card" *ngIf="profileData?.real_estate_market">
         <h5>Real Estate Market</h5>
-        <p><strong>Trends:</strong> {{ profileData.real_estate_market.general_trends }}</p>
+        <p><strong>Trends:</strong> {{ profileData?.real_estate_market?.general_trends }}</p>
         <div *ngIf="profileData?.real_estate_market?.key_areas && (profileData?.real_estate_market?.key_areas?.length ?? 0) > 0">
           <strong>Key Areas:</strong>
           <ul class="profile-list--inline">
-            <li *ngFor="let area of profileData.real_estate_market.key_areas">{{ area }}</li>
+            <li *ngFor="let area of profileData?.real_estate_market?.key_areas">{{ area }}</li>
           </ul>
         </div>
-        <small *ngIf="profileData?.real_estate_market?.source_note"><em>Note: {{ profileData.real_estate_market.source_note }}</em></small>
+        <small *ngIf="profileData?.real_estate_market?.source_note"><em>Note: {{ profileData?.real_estate_market?.source_note }}</em></small>
       </div>
 
       <div class="profile-card" *ngIf="profileData?.principal_trade_partners">
@@ -93,24 +93,24 @@
         <div *ngIf="profileData?.principal_trade_partners?.exports && (profileData?.principal_trade_partners?.exports?.length ?? 0) > 0">
           <strong>Exports:</strong>
           <ul class="profile-list--inline">
-            <li *ngFor="let partner of profileData.principal_trade_partners.exports">{{ partner }}</li>
+            <li *ngFor="let partner of profileData?.principal_trade_partners?.exports">{{ partner }}</li>
           </ul>
         </div>
         <div *ngIf="profileData?.principal_trade_partners?.imports && (profileData?.principal_trade_partners?.imports?.length ?? 0) > 0">
           <strong>Imports:</strong>
           <ul class="profile-list--inline">
-            <li *ngFor="let partner of profileData.principal_trade_partners.imports">{{ partner }}</li>
+            <li *ngFor="let partner of profileData?.principal_trade_partners?.imports">{{ partner }}</li>
           </ul>
         </div>
-        <small *ngIf="profileData?.principal_trade_partners?.source_note"><em>Note: {{ profileData.principal_trade_partners.source_note }}</em></small>
+        <small *ngIf="profileData?.principal_trade_partners?.source_note"><em>Note: {{ profileData?.principal_trade_partners?.source_note }}</em></small>
       </div>
 
       <div class="profile-card" *ngIf="profileData?.currency_details">
         <h5>Currency Details</h5>
-        <p><strong>Code:</strong> {{ profileData.currency_details.currency_code }}</p>
-        <p><strong>Name:</strong> {{ profileData.currency_details.currency_name }}</p>
-        <p><strong>Central Bank:</strong> {{ profileData.currency_details.central_bank }}</p>
-        <small *ngIf="profileData?.currency_details?.exchange_rate_source"><em>Source: {{ profileData.currency_details.exchange_rate_source }}</em></small>
+        <p><strong>Code:</strong> {{ profileData?.currency_details?.currency_code }}</p>
+        <p><strong>Name:</strong> {{ profileData?.currency_details?.currency_name }}</p>
+        <p><strong>Central Bank:</strong> {{ profileData?.currency_details?.central_bank }}</p>
+        <small *ngIf="profileData?.currency_details?.exchange_rate_source"><em>Source: {{ profileData?.currency_details?.exchange_rate_source }}</em></small>
       </div>
 
       <div class="profile-card" *ngIf="profileData.social_indicators_qualitative?.human_development_index as hdi">
@@ -126,26 +126,26 @@
       </div>
        <div class="profile-card" *ngIf="profileData?.employment_by_sector">
         <h5>Employment by Sector</h5>
-        <p *ngIf="profileData?.employment_by_sector?.agriculture">Agriculture: {{profileData.employment_by_sector.agriculture}}</p>
-        <p *ngIf="profileData?.employment_by_sector?.industry">Industry: {{profileData.employment_by_sector.industry}}</p>
-        <p *ngIf="profileData?.employment_by_sector?.services">Services: {{profileData.employment_by_sector.services}}</p>
-        <small *ngIf="profileData?.employment_by_sector?.source_note"><em>Note: {{ profileData.employment_by_sector.source_note }}</em></small>
+        <p *ngIf="profileData?.employment_by_sector?.agriculture">Agriculture: {{profileData?.employment_by_sector?.agriculture}}</p>
+        <p *ngIf="profileData?.employment_by_sector?.industry">Industry: {{profileData?.employment_by_sector?.industry}}</p>
+        <p *ngIf="profileData?.employment_by_sector?.services">Services: {{profileData?.employment_by_sector?.services}}</p>
+        <small *ngIf="profileData?.employment_by_sector?.source_note"><em>Note: {{ profileData?.employment_by_sector?.source_note }}</em></small>
       </div>
       <div class="profile-card" *ngIf="profileData?.public_spending_sectors">
         <h5>Public Spending Sectors (General Info)</h5>
-        <p *ngIf="profileData?.public_spending_sectors?.social_security">Social Security: {{profileData.public_spending_sectors.social_security}}</p>
-        <p *ngIf="profileData?.public_spending_sectors?.education">Education: {{profileData.public_spending_sectors.education}}</p>
-        <p *ngIf="profileData?.public_spending_sectors?.health">Health: {{profileData.public_spending_sectors.health}}</p>
-        <p *ngIf="profileData?.public_spending_sectors?.infrastructure">Infrastructure: {{profileData.public_spending_sectors.infrastructure}}</p>
-        <small *ngIf="profileData?.public_spending_sectors?.source_note"><em>Note: {{ profileData.public_spending_sectors.source_note }}</em></small>
+        <p *ngIf="profileData?.public_spending_sectors?.social_security">Social Security: {{profileData?.public_spending_sectors?.social_security}}</p>
+        <p *ngIf="profileData?.public_spending_sectors?.education">Education: {{profileData?.public_spending_sectors?.education}}</p>
+        <p *ngIf="profileData?.public_spending_sectors?.health">Health: {{profileData?.public_spending_sectors?.health}}</p>
+        <p *ngIf="profileData?.public_spending_sectors?.infrastructure">Infrastructure: {{profileData?.public_spending_sectors?.infrastructure}}</p>
+        <small *ngIf="profileData?.public_spending_sectors?.source_note"><em>Note: {{ profileData?.public_spending_sectors?.source_note }}</em></small>
       </div>
        <div class="profile-card" *ngIf="profileData?.social_indicators_qualitative?.poverty_rate_note">
         <h5>Poverty Rate Note</h5>
-        <p><small><em>{{ profileData.social_indicators_qualitative.poverty_rate_note }}</em></small></p>
+        <p><small><em>{{ profileData?.social_indicators_qualitative?.poverty_rate_note }}</em></small></p>
       </div>
       <div class="profile-card" *ngIf="profileData?.social_indicators_qualitative?.gini_index_source_note">
         <h5>Gini Index Source Note</h5>
-        <p><small><em>{{ profileData.social_indicators_qualitative.gini_index_source_note }}</em></small></p>
+        <p><small><em>{{ profileData?.social_indicators_qualitative?.gini_index_source_note }}</em></small></p>
       </div>
       <div class="profile-card" *ngIf="profileData?.population_demographics_source_note">
         <h5>Population Demographics Source Note</h5>
@@ -154,7 +154,7 @@
 
     </div>
     <div *ngIf="!profileData && !isLoading" class="no-data-message">
-      <p>Economic profile data is currently unavailable for {{ country?.name }}.</p>
+      <p>Economic profile data is currently unavailable for {{ country.name }}.</p>
     </div>
   </div>
 


### PR DESCRIPTION
Resolves NG8107 warning by removing unnecessary optional chaining for `country.name` where its existence is guaranteed by *ngIf.

Fixes multiple NG2 'Object is possibly undefined' errors by applying appropriate optional chaining (`?.`) to nested property accesses within `profileData` in the `uruguay-dashboard-page.component.html` template.

Ensures safe access to potentially undefined properties within the economic profile data, preventing runtime errors and improving template robustness.