### PR TITLE
Fix: Correct optional chaining in Uruguay dashboard template

### DIFF
--- a/progrex-angular-shell/package-lock.json
+++ b/progrex-angular-shell/package-lock.json
@@ -26,7 +26,7 @@
       },
       "devDependencies": {
         "@angular-devkit/build-angular": "^19.2.10",
-        "@angular/cli": "^19.2.10",
+        "@angular/cli": "^19.2.14",
         "@angular/compiler-cli": "^19.2.0",
         "@types/express": "^4.17.17",
         "@types/jasmine": "~5.1.0",
@@ -285,13 +285,12 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "19.2.13",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.2.13.tgz",
-      "integrity": "sha512-NhSPz3lI9njEo8eMUlZVGtlXl12UcNZv5lWTBZY/FGWUu6P5ciD/9iJINbc1jiaDH5E/DLEicUNuai0Q91X4Nw==",
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.2.14.tgz",
+      "integrity": "sha512-s89/MWXHy8+GP/cRfFbSECIG3FQQQwNVv44OOmghPVgKQgQ+EoE/zygL2hqKYTUPoPaS/IhNXdXjSE5pS9yLeg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.2.13",
+        "@angular-devkit/core": "19.2.14",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.17",
         "ora": "5.4.1",
@@ -303,12 +302,38 @@
         "yarn": ">= 1.13.0"
       }
     },
+    "node_modules/@angular-devkit/schematics/node_modules/@angular-devkit/core": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.14.tgz",
+      "integrity": "sha512-aaPEnRNIBoYT4XrrYcZlHadX8vFDTUR+4wUgcmr0cNDLeWzWtoPFeVq8TQD6kFDeqovSx/UVEblGgg/28WvHyg==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "8.17.1",
+        "ajv-formats": "3.0.1",
+        "jsonc-parser": "3.3.1",
+        "picomatch": "4.0.2",
+        "rxjs": "7.8.1",
+        "source-map": "0.7.4"
+      },
+      "engines": {
+        "node": "^18.19.1 || ^20.11.1 || >=22.0.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      },
+      "peerDependencies": {
+        "chokidar": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "chokidar": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@angular-devkit/schematics/node_modules/rxjs": {
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -501,18 +526,17 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "19.2.13",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-19.2.13.tgz",
-      "integrity": "sha512-dDRCS73/lrItWx9j4SmwHR56GiZsW8ObNi2q9l/1ny813CG9K43STYFG/wJvGS7ZF3y5hvjIiJOwBx2YIouOIw==",
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-19.2.14.tgz",
+      "integrity": "sha512-jZvNHAwmyhgUqSIs6OW8YH1rX9XKytm4zPxJol1Xk56F8yAhnrUtukcOi3b7Dv19Z+9eXkwV/Db+2dGjWIE0DA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.1902.13",
-        "@angular-devkit/core": "19.2.13",
-        "@angular-devkit/schematics": "19.2.13",
+        "@angular-devkit/architect": "0.1902.14",
+        "@angular-devkit/core": "19.2.14",
+        "@angular-devkit/schematics": "19.2.14",
         "@inquirer/prompts": "7.3.2",
         "@listr2/prompt-adapter-inquirer": "2.0.18",
-        "@schematics/angular": "19.2.13",
+        "@schematics/angular": "19.2.14",
         "@yarnpkg/lockfile": "1.1.0",
         "ini": "5.0.0",
         "jsonc-parser": "3.3.1",
@@ -532,6 +556,57 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0",
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/@angular/cli/node_modules/@angular-devkit/architect": {
+      "version": "0.1902.14",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1902.14.tgz",
+      "integrity": "sha512-rgMkqOrxedzqLZ8w59T/0YrpWt7LDmGwt+ZhNHE7cn27jZ876yGC2Bhcn58YZh2+R03WEJ9q0ePblaBYz03SMw==",
+      "dev": true,
+      "dependencies": {
+        "@angular-devkit/core": "19.2.14",
+        "rxjs": "7.8.1"
+      },
+      "engines": {
+        "node": "^18.19.1 || ^20.11.1 || >=22.0.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/@angular/cli/node_modules/@angular-devkit/core": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.14.tgz",
+      "integrity": "sha512-aaPEnRNIBoYT4XrrYcZlHadX8vFDTUR+4wUgcmr0cNDLeWzWtoPFeVq8TQD6kFDeqovSx/UVEblGgg/28WvHyg==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "8.17.1",
+        "ajv-formats": "3.0.1",
+        "jsonc-parser": "3.3.1",
+        "picomatch": "4.0.2",
+        "rxjs": "7.8.1",
+        "source-map": "0.7.4"
+      },
+      "engines": {
+        "node": "^18.19.1 || ^20.11.1 || >=22.0.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      },
+      "peerDependencies": {
+        "chokidar": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "chokidar": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@angular/cli/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/@angular/common": {
@@ -4897,20 +4972,55 @@
       ]
     },
     "node_modules/@schematics/angular": {
-      "version": "19.2.13",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-19.2.13.tgz",
-      "integrity": "sha512-SOpK4AwH0isXo7Y2SkgXLyGLMw4GxWPAun6sCLiprmop4KlqKGGALn4xIW0yjq0s5GS0Vx0FFjz8bBfPkgnawA==",
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-19.2.14.tgz",
+      "integrity": "sha512-p/jvMwth67g7tOrziTx+yWRagIPtjx21TF2uU2Pv5bqTY+JjRTczJs3yHPmVpzJN+ptmw47K4/NeLJmVUGuBgA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.2.13",
-        "@angular-devkit/schematics": "19.2.13",
+        "@angular-devkit/core": "19.2.14",
+        "@angular-devkit/schematics": "19.2.14",
         "jsonc-parser": "3.3.1"
       },
       "engines": {
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0",
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/@schematics/angular/node_modules/@angular-devkit/core": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.14.tgz",
+      "integrity": "sha512-aaPEnRNIBoYT4XrrYcZlHadX8vFDTUR+4wUgcmr0cNDLeWzWtoPFeVq8TQD6kFDeqovSx/UVEblGgg/28WvHyg==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "8.17.1",
+        "ajv-formats": "3.0.1",
+        "jsonc-parser": "3.3.1",
+        "picomatch": "4.0.2",
+        "rxjs": "7.8.1",
+        "source-map": "0.7.4"
+      },
+      "engines": {
+        "node": "^18.19.1 || ^20.11.1 || >=22.0.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      },
+      "peerDependencies": {
+        "chokidar": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "chokidar": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@schematics/angular/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/@sigstore/bundle": {

--- a/progrex-angular-shell/package.json
+++ b/progrex-angular-shell/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^19.2.10",
-    "@angular/cli": "^19.2.10",
+    "@angular/cli": "^19.2.14",
     "@angular/compiler-cli": "^19.2.0",
     "@types/express": "^4.17.17",
     "@types/jasmine": "~5.1.0",

--- a/progrex-angular-shell/src/app/features/uruguay-dashboard/pages/uruguay-dashboard-page/uruguay-dashboard-page.component.html
+++ b/progrex-angular-shell/src/app/features/uruguay-dashboard/pages/uruguay-dashboard-page/uruguay-dashboard-page.component.html
@@ -78,14 +78,14 @@
 
       <div class="profile-card" *ngIf="profileData?.real_estate_market">
         <h5>Real Estate Market</h5>
-        <p><strong>Trends:</strong> {{ profileData?.real_estate_market?.general_trends }}</p>
+        <p><strong>Trends:</strong> {{ profileData.real_estate_market?.general_trends }}</p>
         <div *ngIf="profileData?.real_estate_market?.key_areas && (profileData?.real_estate_market?.key_areas?.length ?? 0) > 0">
           <strong>Key Areas:</strong>
           <ul class="profile-list--inline">
             <li *ngFor="let area of profileData?.real_estate_market?.key_areas">{{ area }}</li>
           </ul>
         </div>
-        <small *ngIf="profileData?.real_estate_market?.source_note"><em>Note: {{ profileData?.real_estate_market?.source_note }}</em></small>
+        <small *ngIf="profileData.real_estate_market?.source_note"><em>Note: {{ profileData.real_estate_market?.source_note }}</em></small>
       </div>
 
       <div class="profile-card" *ngIf="profileData?.principal_trade_partners">
@@ -102,15 +102,16 @@
             <li *ngFor="let partner of profileData?.principal_trade_partners?.imports">{{ partner }}</li>
           </ul>
         </div>
-        <small *ngIf="profileData?.principal_trade_partners?.source_note"><em>Note: {{ profileData?.principal_trade_partners?.source_note }}</em></small>
+        <small *ngIf="profileData.principal_trade_partners?.source_note"><em>Note: {{ profileData.principal_trade_partners?.source_note }}</em></small>
       </div>
 
       <div class="profile-card" *ngIf="profileData?.currency_details">
         <h5>Currency Details</h5>
-        <p><strong>Code:</strong> {{ profileData?.currency_details?.currency_code }}</p>
-        <p><strong>Name:</strong> {{ profileData?.currency_details?.currency_name }}</p>
-        <p><strong>Central Bank:</strong> {{ profileData?.currency_details?.central_bank }}</p>
-        <small *ngIf="profileData?.currency_details?.exchange_rate_source"><em>Source: {{ profileData?.currency_details?.exchange_rate_source }}</em></small>
+        <p><strong>Code:</strong> {{ profileData.currency_details?.currency_code }}</p>
+        <p><strong>Name:</strong> {{ profileData.currency_details?.currency_name }}</p>
+        <p><strong>Central Bank:</strong> {{ profileData.currency_details?.central_bank }}</p>
+        <small *ngIf="profileData.currency_details?.exchange_rate_source"><em>Source: {{ profileData.currency_details?.exchange_rate_source }}</em></small>
+
       </div>
 
       <div class="profile-card" *ngIf="profileData.social_indicators_qualitative?.human_development_index as hdi">
@@ -126,26 +127,26 @@
       </div>
        <div class="profile-card" *ngIf="profileData?.employment_by_sector">
         <h5>Employment by Sector</h5>
-        <p *ngIf="profileData?.employment_by_sector?.agriculture">Agriculture: {{profileData?.employment_by_sector?.agriculture}}</p>
-        <p *ngIf="profileData?.employment_by_sector?.industry">Industry: {{profileData?.employment_by_sector?.industry}}</p>
-        <p *ngIf="profileData?.employment_by_sector?.services">Services: {{profileData?.employment_by_sector?.services}}</p>
-        <small *ngIf="profileData?.employment_by_sector?.source_note"><em>Note: {{ profileData?.employment_by_sector?.source_note }}</em></small>
+        <p *ngIf="profileData.employment_by_sector?.agriculture">Agriculture: {{profileData.employment_by_sector?.agriculture}}</p>
+        <p *ngIf="profileData.employment_by_sector?.industry">Industry: {{profileData.employment_by_sector?.industry}}</p>
+        <p *ngIf="profileData.employment_by_sector?.services">Services: {{profileData.employment_by_sector?.services}}</p>
+        <small *ngIf="profileData.employment_by_sector?.source_note"><em>Note: {{ profileData.employment_by_sector?.source_note }}</em></small>
       </div>
       <div class="profile-card" *ngIf="profileData?.public_spending_sectors">
         <h5>Public Spending Sectors (General Info)</h5>
-        <p *ngIf="profileData?.public_spending_sectors?.social_security">Social Security: {{profileData?.public_spending_sectors?.social_security}}</p>
-        <p *ngIf="profileData?.public_spending_sectors?.education">Education: {{profileData?.public_spending_sectors?.education}}</p>
-        <p *ngIf="profileData?.public_spending_sectors?.health">Health: {{profileData?.public_spending_sectors?.health}}</p>
-        <p *ngIf="profileData?.public_spending_sectors?.infrastructure">Infrastructure: {{profileData?.public_spending_sectors?.infrastructure}}</p>
-        <small *ngIf="profileData?.public_spending_sectors?.source_note"><em>Note: {{ profileData?.public_spending_sectors?.source_note }}</em></small>
+        <p *ngIf="profileData.public_spending_sectors?.social_security">Social Security: {{profileData.public_spending_sectors?.social_security}}</p>
+        <p *ngIf="profileData.public_spending_sectors?.education">Education: {{profileData.public_spending_sectors?.education}}</p>
+        <p *ngIf="profileData.public_spending_sectors?.health">Health: {{profileData.public_spending_sectors?.health}}</p>
+        <p *ngIf="profileData.public_spending_sectors?.infrastructure">Infrastructure: {{profileData.public_spending_sectors?.infrastructure}}</p>
+        <small *ngIf="profileData.public_spending_sectors?.source_note"><em>Note: {{ profileData.public_spending_sectors?.source_note }}</em></small>
       </div>
-       <div class="profile-card" *ngIf="profileData?.social_indicators_qualitative?.poverty_rate_note">
+       <div class="profile-card" *ngIf="profileData.social_indicators_qualitative?.poverty_rate_note">
         <h5>Poverty Rate Note</h5>
-        <p><small><em>{{ profileData?.social_indicators_qualitative?.poverty_rate_note }}</em></small></p>
+        <p><small><em>{{ profileData.social_indicators_qualitative?.poverty_rate_note }}</em></small></p>
       </div>
-      <div class="profile-card" *ngIf="profileData?.social_indicators_qualitative?.gini_index_source_note">
+      <div class="profile-card" *ngIf="profileData.social_indicators_qualitative?.gini_index_source_note">
         <h5>Gini Index Source Note</h5>
-        <p><small><em>{{ profileData?.social_indicators_qualitative?.gini_index_source_note }}</em></small></p>
+        <p><small><em>{{ profileData.social_indicators_qualitative?.gini_index_source_note }}</em></small></p>
       </div>
       <div class="profile-card" *ngIf="profileData?.population_demographics_source_note">
         <h5>Population Demographics Source Note</h5>


### PR DESCRIPTION
This commit addresses Angular compiler warnings (NG8107) and errors (NG2) in the `UruguayDashboardPageComponent` template:

- Corrected unnecessary optional chaining for `social_indicators_qualitative` when accessing `poverty_rate_note` and `gini_index_source_note`. The properties `poverty_rate_note` and `gini_index_source_note` themselves can be undefined, so optional chaining was moved to them (e.g., `profileData.social_indicators_qualitative?.poverty_rate_note`).
- Added necessary optional chaining (`?.`) to other `profileData` properties that were causing "Object is possibly 'undefined'" (NG2) errors.

These changes ensure the template is robust against potentially missing data and resolves build-time warnings and errors.